### PR TITLE
Bug fix series to list

### DIFF
--- a/python_dwd/constants/access_credentials.py
+++ b/python_dwd/constants/access_credentials.py
@@ -4,6 +4,7 @@ DWD_PATH = 'climate_environment/CDC/observations_germany/climate'
 DWD_USER = 'anonymous'
 DWD_PASSWORD = ''
 FTP_EXPRESSION = 'ftp://'
+HTTPS_EXPRESSION = 'https://'
 
 DWD_FOLDER_MAIN = './dwd_data'
 DWD_FOLDER_METADATA = 'metadata'

--- a/python_dwd/download/download.py
+++ b/python_dwd/download/download.py
@@ -12,6 +12,7 @@ from python_dwd.constants.metadata import STATIONDATA_MATCHSTRINGS
 from python_dwd.download.download_services import create_remote_file_name
 from python_dwd.additionals.functions import find_all_matchstrings_in_string
 from python_dwd.enumerations.column_names_enumeration import DWDMetaColumns
+from python_dwd.exceptions.failed_download_exception import FailedDownload
 
 
 def download_dwd_data(remote_files: pd.DataFrame,
@@ -55,7 +56,7 @@ def _download_dwd_data(remote_file: Union[str, Path]) -> BytesIO:
     except urllib.error.URLError as e:
         raise e(f"Error: the stationdata {file_server} couldn't be reached.")
     except:
-        print(file_server)
+        raise FailedDownload(f"Download failed for {file_server}")
 
     try:
         with zipfile.ZipFile(zip_file) as zip_file_opened:

--- a/python_dwd/download/download.py
+++ b/python_dwd/download/download.py
@@ -18,7 +18,7 @@ def download_dwd_data(remote_files: pd.DataFrame,
                       parallel_download: bool = False) -> List[Tuple[str, BytesIO]]:
     """ wrapper for _download_dwd_data to provide a multiprocessing feature"""
 
-    remote_files: List[str] = remote_files[DWDMetaColumns.FILENAME.value].to_list()
+    remote_files = remote_files[DWDMetaColumns.FILENAME.value].values.tolist()
 
     if parallel_download:
         return list(

--- a/python_dwd/download/download.py
+++ b/python_dwd/download/download.py
@@ -52,10 +52,10 @@ def _download_dwd_data(remote_file: Union[str, Path]) -> BytesIO:
     try:
         with urllib.request.urlopen(file_server) as url_request:
             zip_file = BytesIO(url_request.read())
-    except urllib.error.URLError:
-        raise urllib.error.URLError(f"Error: the stationdata {file_server} couldn't be reached.")
-    except urllib.error.HTTPError:
-        pass
+    except urllib.error.URLError as e:
+        raise e(f"Error: the stationdata {file_server} couldn't be reached.")
+    except:
+        print(file_server)
 
     try:
         with zipfile.ZipFile(zip_file) as zip_file_opened:

--- a/python_dwd/download/download_services.py
+++ b/python_dwd/download/download_services.py
@@ -2,7 +2,7 @@
 from pathlib import Path, PurePosixPath
 from typing import Union
 
-from python_dwd.constants.access_credentials import DWD_FOLDER_STATIONDATA, DWD_SERVER, DWD_PATH, FTP_EXPRESSION
+from python_dwd.constants.access_credentials import DWD_FOLDER_STATIONDATA, DWD_SERVER, DWD_PATH, HTTPS_EXPRESSION
 
 
 def create_local_file_name(remote_file_path: Union[Path, str],
@@ -32,4 +32,4 @@ def create_remote_file_name(file: str) -> str:
                                 DWD_PATH,
                                 file)
 
-    return f"{FTP_EXPRESSION}{file_server}"
+    return f"{HTTPS_EXPRESSION}{file_server}"

--- a/python_dwd/enumerations/column_names_enumeration.py
+++ b/python_dwd/enumerations/column_names_enumeration.py
@@ -40,6 +40,10 @@ class DWDOrigColumns(Enum):
     TNK = "TNK"
     TGK = "TGK"
 
+    # 10 minutes data
+    FX_10 = "FX_10"
+    DX_10 = "DX_10"
+
 
 class DWDMetaColumns(Enum):
     """ Overhauled column names for metadata fields """
@@ -61,7 +65,7 @@ class DWDMetaColumns(Enum):
 
 class DWDDataColumns(Enum):
     """ Overhauled column names for data fields """
-
+    DATE = "DATE"
     # Daily climate summary
     FX = "WIND_GUST_MAX"
     FM = "WIND_VELOCITY"

--- a/python_dwd/exceptions/failed_download_exception.py
+++ b/python_dwd/exceptions/failed_download_exception.py
@@ -1,0 +1,6 @@
+""" Exception that can be thrown if download fails"""
+
+
+class FailedDownload(Exception):
+    """ Failed download exception """
+    pass


### PR DESCRIPTION
I had to change the FTP_EXPRESSION to HTTPS_EXPRESSION and the `to_list()` is not working with the pd.Series.

type hinting is not necessary at this point. If you parse pd.Series to numpy.array and a numpy.array to a List, the output is a List defined by the called pipeline. 

